### PR TITLE
Create a reproducible test for https://github.com/jenkinsci/custom-war-packager/pull/63

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 ARTIFACT_ID = jenkinsfile-runner-demo
 VERSION = 256.0-test
 CWP_MAVEN_REPO_PATH=io/jenkins/tools/custom-war-packager/custom-war-packager-cli
-CWP_VERSION=1.5
+CWP_VERSION=1.6-20181219.101124-1
 DOCKER_TAG=onenashev/ci.jenkins.io-runner
 PIPELINE_LIBRARY_DIR=/Users/nenashev/Documents/jenkins/infra/pipeline-library/
 

--- a/init_scripts/src/main/groovy/System.groovy
+++ b/init_scripts/src/main/groovy/System.groovy
@@ -9,3 +9,7 @@ Jenkins.instance.quietPeriod = 0
 
 JenkinsLocationConfiguration.get().adminAddress = "admin@non.existent.email"
 Mailer.descriptor().defaultSuffix = "@non.existent.email"
+
+println "===== TEST CLASSLOADING ==="
+URLClassLoader cl = (URLClassLoader)Class.forName("org.kohsuke.stapler.EvaluationTrace.ApplicationTracer").getClassLoader()
+println "URLs of the classloader: ${cl.URLs}"

--- a/packager-config.yml
+++ b/packager-config.yml
@@ -1,6 +1,6 @@
 bundle:
-  groupId: "io.jenkins.tools.ci-jenkins.io.runner"
-  artifactId: "jenkinsfile-runner"
+  groupId: "io.jenkins.jenkinsfile-runner.demo"
+  artifactId: "ci.jenkins.io-runner"
   vendor: "Oleg Nenashev"
   title: "ci.jenkins.io Runner"
   description: "Emulates the ci.jenkins.io environment, as Jenkinsfile Runner"
@@ -9,13 +9,10 @@ buildSettings:
   pomIgnoreRoot: true
   jenkinsfileRunner:
     source:
-      groupId: "io.jenkins"
+      groupId: "io.jenkins.jenkinsfile-runner"
       artifactId: "jenkinsfile-runner"
-      build:
-        noCache: true
       source:
-        git: https://github.com/jenkinsci/jenkinsfile-runner.git
-        commit: 66626ef7c95c281d5b3ef9da9f5fdc36b4b42bf0
+        version: 1.0-beta-4
     docker:
       base: "jenkins/ci.jenkins.io-runner.base"
       tag: "onenashev/ci.jenkins.io-runner"
@@ -24,7 +21,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.138.3"
+    version: "2.156"
 systemProperties:
   jenkins.model.Jenkins.slaveAgentPort: "50000"
   jenkins.model.Jenkins.slaveAgentPortEnforce: "true"


### PR DESCRIPTION
Reproduces the issue we hit for https://github.com/jenkinsci/custom-war-packager/pull/63

```
===== TEST CLASSLOADING ===
  16.616 [id=26]	SEVERE	jenkins.InitReactorRunner$1#onTaskFailed: Failed GroovyInitScript.init
java.lang.ClassNotFoundException: org.kohsuke.stapler.EvaluationTrace.ApplicationTracer
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at groovy.lang.GroovyClassLoader.loadClass(GroovyClassLoader.java:677)
	at groovy.lang.GroovyClassLoader$InnerLoader.loadClass(GroovyClassLoader.java:425)
	at groovy.lang.GroovyClassLoader.loadClass(GroovyClassLoader.java:787)
	at groovy.lang.GroovyClassLoader.loadClass(GroovyClassLoader.java:775)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at System.run(System.groovy:14)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:585)
	at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:136)
	at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:119)
	at jenkins.util.groovy.GroovyHookScript.run(GroovyHookScript.java:89)
	at hudson.init.impl.GroovyInitScript.init(GroovyInitScript.java:41)
Caused: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
Caused: java.lang.Error
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:110)

```